### PR TITLE
Fixed list styling

### DIFF
--- a/assets/css/erm-front.css
+++ b/assets/css/erm-front.css
@@ -1,8 +1,8 @@
 /* Menu general */
 .erm_menu:not(.type-erm_menu) { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; }
 .erm_menu:not(.type-erm_menu),
-.erm_menu:not(.type-erm_menu) ul { list-style: none !important; margin: 0!important; padding: 0!important; }
-.erm_menu:not(.type-erm_menu) li { margin-left: 0px !important;; }
+.erm_menu:not(.type-erm_menu) ul { margin: 0!important; padding: 0!important; }
+.erm_menu:not(.type-erm_menu) li { margin-left: 0px !important; list-style: none; }
 
 .erm_menu:not(.type-erm_menu) { border-top: 6px solid black; margin: 30px 0px; }
 .type-erm_menu .erm_menu { border-top: none; }

--- a/templates/menu-item-product.php
+++ b/templates/menu-item-product.php
@@ -1,3 +1,9 @@
+<?php
+$visible = get_post_meta( $item_id, '_erm_visible', true );
+$prices = get_post_meta( $item_id, '_erm_prices', true );
+if ( !$visible ) return;
+?>
+
 <?php $has_thumbnail = has_post_thumbnail( $item_id ); ?>
 
 <li class="erm_product <?php echo ( ($has_thumbnail && $show_thumbnails) ? 'with_image' : 'no_image'); ?>">
@@ -24,22 +30,17 @@
     }
     ?>
 
-    <h3 class="erm_product_title"><?php echo $the_post->post_title; ?></h3>
+    <h3 class="erm_product_title"><?php echo $the_post->post_title;?>
+        
+        <!-- Display Price next to name of item instead of in another span.  Removed logic to check if the price should be displayed on top or bottom-->
+        <?php foreach( $prices as $price ) { ?>
+                    
+        <?php echo apply_filters('erm_filter_price', $price['value']); ?>
+            <?php } ?>
+    </h3>
 
     <?php
-
-    if ( $price_position == 'top' ) {
-
-        include 'menu-item-product-price.php';
         include 'menu-item-product-desc.php';
-
-    } else if ( $price_position == 'bottom' ) {
-
-        include 'menu-item-product-desc.php';
-        include 'menu-item-product-price.php';
-
-    }
-
     ?>
 
     <div class="clear"></div>


### PR DESCRIPTION
By default list items still had a bullet next to them because the list-style: none attribute was applied to the list instead of the list items.
Moved list-style: none from ul tag to li tag, removed !important since not needed.